### PR TITLE
JAHIACOM-1328: Overlapping of the "copy" button for code snippet

### DIFF
--- a/src/main/resources/scss/custom/_content.scss
+++ b/src/main/resources/scss/custom/_content.scss
@@ -112,7 +112,9 @@ $list-puce-size: 22px;
   pre {
     white-space: pre;
     padding: spacing(3);
-    padding-top: spacing(5);
+    @include media-breakpoint-up(md) {
+      padding-top: spacing(5);
+    }
     background-color: $gray-100;
     border: 0;
     border-radius: $border-radius;

--- a/src/main/resources/scss/custom/_content.scss
+++ b/src/main/resources/scss/custom/_content.scss
@@ -112,6 +112,7 @@ $list-puce-size: 22px;
   pre {
     white-space: pre;
     padding: spacing(3);
+    padding-top: spacing(5);
     background-color: $gray-100;
     border: 0;
     border-radius: $border-radius;


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://support.jahia.com/browse/JAHIACOM-1328

## Description

Increase the top padding so the "Copy" button available in code snippet does not overlap with the code below, especially for long lines.


### Before:
![image](https://github.com/user-attachments/assets/34766f46-f42f-4e9e-9c72-10d1262aacab)

### After:

<img width="767" alt="image" src="https://github.com/user-attachments/assets/660cb157-3f77-49f2-bfb2-fb4142c345e7">


<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

## Tests

N/A

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [x] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [x] Performance
- [x] Migration
- [x] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
