### PR TITLE
fix(code-blocks): line numbers layout, contrast, and Bootstrap table conflict

### DIFF
--- a/src/main/resources/jacademy_textContent/html/textContent.jsp
+++ b/src/main/resources/jacademy_textContent/html/textContent.jsp
@@ -25,6 +25,7 @@ ${currentNode.properties.textContent.string}
             $('code.hljs').each(function (i, block) {
                 hljs.lineNumbersBlock(block);
             });
+            $('.hljs-ln-numbers').attr('aria-hidden', 'true');
         });
 
         // Insert copy to clipboard button before .highlight

--- a/src/main/resources/scss/custom/_content.scss
+++ b/src/main/resources/scss/custom/_content.scss
@@ -134,7 +134,7 @@ $list-puce-size: 22px;
   }
 
   // prevent the overlapping of the "In this page" section
-  table {
+  table:not(.hljs-ln) {
     @extend .table;
     @extend .table-striped;
     table-layout: fixed

--- a/src/main/resources/scss/custom/_custom.scss
+++ b/src/main/resources/scss/custom/_custom.scss
@@ -49,8 +49,8 @@ html {
 
   &-line-numbers {
     text-align: right;
-    border-right: 1px solid #ccc;
-    color: #999;
+    border-right: 1px solid $gray-600;
+    color: $gray-600;
     -webkit-touch-callout: none;
     user-select: none;
   }
@@ -61,14 +61,21 @@ html {
     text-align: right;
   }
 
-  td &-ln-numbers {
-    border-right: 1px solid #ccc;
-    color: #ccc;
+  &-ln {
+    white-space: normal;
   }
 
-  td &-ln-code {
+  &-ln-numbers {
+    border-right: 1px solid $gray-600;
+    color: $gray-600;
+    user-select: none;
+    width: 1%;
+    white-space: nowrap;
+  }
+
+  &-ln-code {
     padding-left: 10px !important;
-    width: 100%;
+    white-space: pre;
   }
 }
 


### PR DESCRIPTION
Closes #16

## Summary

- Fix broken SCSS selectors on `.hljs-ln-numbers` / `.hljs-ln-code` (compiled to descendant selectors that never matched)
- Exclude `.hljs-ln` from Bootstrap `.table` / `.table-striped` to prevent row borders and striped backgrounds on code blocks
- Reset `white-space: normal` on `.hljs-ln` table (inherited `pre { white-space: pre }` was breaking column layout)
- Use `width: 1%; white-space: nowrap` on numbers column so it shrink-wraps and code column fills remaining space
- Replace `color: #ccc` / `border: #ccc` with `$gray-600` — WCAG AA compliant (~4.5:1 on `$gray-100`)
- Add `aria-hidden="true"` on line number cells so screen readers skip them

## Test plan

- [ ] Multi-line code blocks (JSON, bash) show line numbers correctly aligned with code
- [ ] No blank space / overlap between numbers column and code
- [ ] No Bootstrap row borders or striped rows on code blocks
- [ ] Regular content tables still have Bootstrap `.table` / `.table-striped` styles
- [ ] Line numbers are visually subdued (gray) and readable
- [ ] Screen reader does not announce line numbers before each line of code

🤖 Generated with [Claude Code](https://claude.com/claude-code)